### PR TITLE
Fix Tesseract path configuration

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -7,9 +7,11 @@ import json
 import os
 import re
 from datetime import datetime
+import platform
 
-# 👇 Fuerza el path manualmente (Windows)
-pytesseract.pytesseract.tesseract_cmd = r"C:\Program Files\Tesseract-OCR\tesseract.exe"
+# 👇 Configura manualmente la ruta solo en Windows
+if platform.system() == "Windows":
+    pytesseract.pytesseract.tesseract_cmd = r"C:\Program Files\Tesseract-OCR\tesseract.exe"
 
 app = FastAPI()
 


### PR DESCRIPTION
## Summary
- set Tesseract path only on Windows for cross-platform support

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_689967a340c08326a228d3a5a63fa4af