### PR TITLE
Protect dashboard page with auth redirect

### DIFF
--- a/dashboard/app/dashboard/page.tsx
+++ b/dashboard/app/dashboard/page.tsx
@@ -1,5 +1,33 @@
+"use client"
+
+import { useEffect } from "react"
+import { useRouter } from "next/navigation"
+import { useAuth } from "@/components/auth-provider"
 import GastoAgilDashboard from "@/components/gastoagil/dashboard"
 
 export default function DashboardPage() {
+  const { isAuthenticated, isLoading } = useAuth()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (!isLoading && !isAuthenticated) {
+      router.push("/auth/login")
+    }
+  }, [isAuthenticated, isLoading, router])
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-gray-50 dark:bg-[#0F0F12] flex items-center justify-center">
+        <div className="text-center">
+          <div className="w-12 h-12 bg-blue-600 rounded-lg flex items-center justify-center mx-auto mb-4">
+            <span className="text-white font-bold text-xl">GA</span>
+          </div>
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto"></div>
+          <p className="mt-4 text-gray-600 dark:text-gray-400">Cargando...</p>
+        </div>
+      </div>
+    )
+  }
+
   return <GastoAgilDashboard />
 }


### PR DESCRIPTION
## Summary
- Enforce authentication on the dashboard page, redirecting unauthenticated users to the login screen.
- Display a loading indicator while verifying session state to avoid flicker during auth checks.

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68996a63fac88326a0272e1d14898cf9