### PR TITLE
feat: navigate to login on logout

### DIFF
--- a/dashboard/components/auth-provider.tsx
+++ b/dashboard/components/auth-provider.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { createContext, useContext, useState, useEffect, type ReactNode } from "react"
+import { useRouter } from "next/navigation"
 
 interface User {
   id: string
@@ -26,6 +27,7 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined)
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null)
   const [isLoading, setIsLoading] = useState(true)
+  const router = useRouter()
 
   // Simular verificación de autenticación al cargar
   useEffect(() => {
@@ -110,6 +112,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const logout = () => {
     setUser(null)
     localStorage.removeItem("gastoagil_user")
+    router.push("/auth/login")
   }
 
   const value = {

--- a/dashboard/components/kokonutui/profile-01.tsx
+++ b/dashboard/components/kokonutui/profile-01.tsx
@@ -6,7 +6,6 @@ import { LogOut, MoveUpRight, Settings, CreditCard, FileText } from "lucide-reac
 import Image from "next/image"
 import Link from "next/link"
 import { useAuth } from "@/components/auth-provider"
-import { useRouter } from "next/navigation"
 
 interface MenuItem {
   label: string
@@ -30,11 +29,9 @@ export default function Profile01({
   subscription = "Plan Básico",
 }: Profile01Props) {
   const { logout } = useAuth()
-  const router = useRouter()
 
   const handleLogout = () => {
     logout()
-    router.push("/")
   }
 
   const menuItems: MenuItem[] = [


### PR DESCRIPTION
## Summary
- redirect to login when logging out
- remove extra router push from profile menu

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: prompted for ESLint setup)


------
https://chatgpt.com/codex/tasks/task_e_68996a67551883268041001addf05fde